### PR TITLE
Remove dependency on skeptic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,9 @@
 [package]
 name = "swapper"
-version = "0.0.4"
+version = "0.1.0"
 authors = ["ajeffrey@mozilla.com"]
 repository = "https://github.com/asajeffrey/swapper"
 documentation = "https://docs.rs/swapper"
 description = "Swap ownership between threads"
 keywords = ["concurrency"]
 license = "MPL-2.0"
-build = "build.rs"
-
-[lib]
-
-[build-dependencies]
-skeptic = "0.9"
-
-[dev-dependencies]
-skeptic = "0.9"

--- a/README.md.skt.md
+++ b/README.md.skt.md
@@ -1,8 +1,0 @@
-```rust,skt-main
-extern crate swapper;
-use std::thread;
-fn main() {{
-    {}
-}}
-
-```

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
Because it is a build-dependency, it was built when using swapper as a library even if not running swapper’s tests.

This makes the example in README.md not be tested anymore, but the `tests/lib.rs` has the same test already.